### PR TITLE
should override OnNavigatedTo

### DIFF
--- a/docs/xamarin-forms/navigation/passing-parameters.md
+++ b/docs/xamarin-forms/navigation/passing-parameters.md
@@ -67,19 +67,19 @@ Example:
 ```cs
 public class ContactPageViewModel : INavigationAware
 {  
-  public void OnNavigatedTo(NavigationParameters parameters)
+  public override void OnNavigatedTo(INavigationParameters parameters)
   {
 
   }
   
-  public void OnNavigatingTo(NavigationParameters parameters)
+  public override void OnNavigatedFrom(INavigationParameters parameters)
   {
-    
+  
   }
 
-  public void OnNavigatedFrom(NavigationParameters parameters)
+  public override void OnNavigatingTo(INavigationParameters parameters)
   {
-
+  
   }
 }
 ```


### PR DESCRIPTION
At least in the case of Prism for Xamarin.Forms these Navigation-aware methods as written do not work, because the virtual void methods in the ViewModelBase all take an INavigationParameters argument, not NavigationParameters. Also they should be overrides.