### PR TITLE
Updated ObservesCanExecute section

### DIFF
--- a/docs/commanding.md
+++ b/docs/commanding.md
@@ -143,7 +143,7 @@ public class ArticleViewModel : BindableBase
 
     public ArticleViewModel()
     {
-        SubmitCommand = new DelegateCommand(Submit, CanSubmit).ObservesCanExecute(() => IsEnabled);
+        SubmitCommand = new DelegateCommand(Submit).ObservesCanExecute(() => IsEnabled);
     }
 
     void Submit()


### PR DESCRIPTION
ObservesCanExecute section of the documentation should not have the 'CanExecute' delegate passed to the DelegateCommand constructor.