### PR TITLE
Fixed property type

### DIFF
--- a/docs/commands/commanding.md
+++ b/docs/commands/commanding.md
@@ -24,7 +24,7 @@ The Prism `DelegateCommand` class encapsulates two delegates that each reference
 ```cs
 public class ArticleViewModel
 {
-    public DelegateCommand SubmitCommand { get; private set; }
+    public DelegateCommand<object> SubmitCommand { get; private set; }
 
     public ArticleViewModel()
     {


### PR DESCRIPTION
Object of type `DelegateCommand<object>` cannot be assigned to the `DelegateCommand` property. Fixed property type according to the context of the example