### PR TITLE
Fix incorrect Prism xmlns in WPF event-to-command docs

### DIFF
--- a/docs/platforms/wpf/interactivity/event-to-command.md
+++ b/docs/platforms/wpf/interactivity/event-to-command.md
@@ -25,7 +25,7 @@ First the binding needs to be hooked up in WPF by specifying an ```InteractionTr
 
 Add the `Prism` namespace to be able to declare `InvokeCommandAction` in the XAML.
 
-`xmlns:prism="http://prismlibrary.com"`
+`xmlns:prism="http://prismlibrary.com/"`
 
 And attach to the control with the desired event.
 


### PR DESCRIPTION
The WPF "Event to Command" documentation page shows the Prism XML namespace
without the trailing slash:

`xmlns:prism="http://prismlibrary.com"`

This value does not work correctly in XAML, while the examples on the same
page use:

`xmlns:prism="http://prismlibrary.com/"`

This PR updates the documentation to include the trailing slash so the
snippet is valid XAML.

Fixes #130
